### PR TITLE
Migrate plugin to Moodle 5.2 and Bootstrap 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:16
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -16,7 +16,7 @@ jobs:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.11
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -30,13 +30,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4', '8.0', '8.1', '8.2']
-        moodle-branch: ['MOODLE_39_STABLE', 'MOODLE_310_STABLE', 'MOODLE_311_STABLE', 'MOODLE_400_STABLE', 'MOODLE_401_STABLE', 'MOODLE_402_STABLE', 'MOODLE_403_STABLE']
+        php: ['8.3', '8.4']
+        moodle-branch: ['MOODLE_502_STABLE']
         database: [pgsql, mariadb]
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: plugin
 
@@ -51,7 +51,7 @@ jobs:
 
       - name: Initialise moodle-plugin-ci
         run: |
-          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+          composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^4
           echo $(cd ci/bin; pwd) >> $GITHUB_PATH
           echo $(cd ci/vendor/bin; pwd) >> $GITHUB_PATH
           sudo locale-gen en_AU.UTF-8

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 ## Changelog ##
 
+- [1.1.0]:
+    - Migrated the plugin to Moodle 5.2.
+        - Raised the minimum required Moodle version to 5.2 (2026042000).
+        - Migrated templates and views from Bootstrap 4 to Bootstrap 5 (directional spacing utilities, dismissible alerts and close buttons).
+        - Removed dead pre-Moodle 4.0 backward compatibility code.
+
 - [1.0.3]:
     - Ensured compatibility with Moodle 4.3.
         - Changed code to comply with new moodle coding standards.

--- a/lib.php
+++ b/lib.php
@@ -34,11 +34,6 @@
  */
 function pingo_supports($feature) {
 
-    // Adding support for FEATURE_MOD_PURPOSE (MDL-71457) and providing backward compatibility (pre-v4.0).
-    if (defined('FEATURE_MOD_PURPOSE') && $feature === FEATURE_MOD_PURPOSE) {
-        return MOD_PURPOSE_COMMUNICATION;
-    }
-
     switch ($feature) {
         case FEATURE_MOD_INTRO:
             return true;
@@ -48,6 +43,8 @@ function pingo_supports($feature) {
             return true;
         case FEATURE_BACKUP_MOODLE2:
             return true;
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_COMMUNICATION;
 
         default:
             return null;

--- a/templates/pingo_sessionsoverview.mustache
+++ b/templates/pingo_sessionsoverview.mustache
@@ -57,7 +57,7 @@
                         <td>{{name}} ({{token}})</td>
                         <td>{{description}}</td>
                         <td>
-                            <a class="btn btn-primary mr-1" href="view.php?id={{cmid}}&session={{token}}&mode=4" title="{{#str}}show{{/str}}">
+                            <a class="btn btn-primary me-1" href="view.php?id={{cmid}}&session={{token}}&mode=4" title="{{#str}}show{{/str}}">
                                 <i class="fa fa-eye" title="{{#str}}show{{/str}}"></i>
                             </a>
                             <a class="btn btn-primary" href="view.php?id={{cmid}}&session={{token}}&mode=2" title="{{#str}}quicksurvey, mod_pingo{{/str}}">{{#str}}quicksurvey, mod_pingo{{/str}}</a>

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_pingo';
-$plugin->release = '1.0.3';
-$plugin->version = 2023102300;
-$plugin->requires = 2020061507;
+$plugin->release = '1.1.0';
+$plugin->version = 2026060700;
+$plugin->requires = 2026042000; // Moodle 5.2.
 $plugin->maturity = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -427,20 +427,7 @@ if (!$activeconnection) { // Login.
     redirect($redirecturl, get_string('sessionactivated', 'mod_pingo'), null, notification::NOTIFY_SUCCESS);
 }
 
-// Add settingsmenu and heading for moodle < 400.
-if ($CFG->branch < 400) {
-    $PAGE->force_settings_menu();
-}
-
 echo $OUTPUT->header();
-
-if ($CFG->branch < 400) {
-    echo $OUTPUT->heading($modulename);
-
-    if ($moduleinstance->intro) {
-        echo $OUTPUT->box(format_module_intro('pingo', $moduleinstance, $cm->id), 'generalbox', 'intro');
-    }
-}
 
 $viewoverview = has_capability('mod/pingo:viewoverview', $context);
 $viewallsessions = has_capability('mod/pingo:viewallsessions', $context);
@@ -526,8 +513,9 @@ if ($viewoverview && ($moduleinstance->editableforall || (!$activeconnection || 
                 $urlparams = ['id' => $id, 'session' => $session, 'mode' => 2];
                 $redirecturl = new moodle_url('/mod/pingo/view.php', $urlparams);
 
-                echo '<div class="alert alert-danger alert-block fade in m-2" role="alert">';
-                echo '<button type="button" class="close" data-dismiss="alert">×</button>';
+                echo '<div class="alert alert-danger alert-dismissible fade show m-2" role="alert">';
+                echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' .
+                    get_string('closebuttontitle') . '"></button>';
                 echo get_string('errfetching', 'mod_pingo') . '</div>';
                 echo '<a class="btn btn-primary" href="' . $redirecturl . '">' . get_string('reloadpage', 'mod_pingo') . '</a>';
             }
@@ -559,8 +547,9 @@ if ($viewoverview && ($moduleinstance->editableforall || (!$activeconnection || 
                 $urlparams = ['id' => $id, 'session' => $session, 'mode' => 3];
                 $redirecturl = new moodle_url('/mod/pingo/view.php', $urlparams);
 
-                echo '<div class="alert alert-danger alert-block fade in m-2" role="alert">';
-                echo '<button type="button" class="close" data-dismiss="alert">×</button>';
+                echo '<div class="alert alert-danger alert-dismissible fade show m-2" role="alert">';
+                echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' .
+                    get_string('closebuttontitle') . '"></button>';
                 echo get_string('errfetching', 'mod_pingo') . '</div>';
                 echo '<a class="btn btn-primary" href="' . $redirecturl . '">' . get_string('reloadpage', 'mod_pingo') . '</a>';
             }
@@ -622,8 +611,9 @@ if ($viewoverview && ($moduleinstance->editableforall || (!$activeconnection || 
                     $urlparams = ['id' => $id, 'session' => $session, 'mode' => 4];
                     $redirecturl = new moodle_url('/mod/pingo/view.php', $urlparams);
 
-                    echo '<div class="alert alert-danger alert-block fade in m-2" role="alert">';
-                    echo '<button type="button" class="close" data-dismiss="alert">×</button>';
+                    echo '<div class="alert alert-danger alert-dismissible fade show m-2" role="alert">';
+                    echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' .
+                        get_string('closebuttontitle') . '"></button>';
                     echo get_string('errfetching', 'mod_pingo') . '</div>';
                     echo '<a class="btn btn-primary" href="' . $redirecturl . '">' . get_string('reloadpage', 'mod_pingo') . '</a>';
                 }
@@ -644,8 +634,9 @@ if ($viewoverview && ($moduleinstance->editableforall || (!$activeconnection || 
 } else { // Student view.
 
     if ($viewoverview && $activeconnection && $USER->id != $activeconnection->userid) {
-        echo '<div class="alert alert-danger alert-block fade in m-2" role="alert">';
-        echo '<button type="button" class="close" data-dismiss="alert">×</button>';
+        echo '<div class="alert alert-danger alert-dismissible fade show m-2" role="alert">';
+        echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' .
+            get_string('closebuttontitle') . '"></button>';
         echo get_string('errnotallowedforotherteachers', 'mod_pingo') . '</div>';
     }
 
@@ -684,8 +675,9 @@ if ($viewoverview && ($moduleinstance->editableforall || (!$activeconnection || 
                 $urlparams = ['id' => $id, 'mode' => 1];
                 $redirecturl = new moodle_url('/mod/pingo/view.php', $urlparams);
 
-                echo '<div class="alert alert-danger alert-block fade in m-2" role="alert">';
-                echo '<button type="button" class="close" data-dismiss="alert">×</button>';
+                echo '<div class="alert alert-danger alert-dismissible fade show m-2" role="alert">';
+                echo '<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="' .
+                    get_string('closebuttontitle') . '"></button>';
                 echo get_string('errfetching', 'mod_pingo') . '</div>';
                 echo '<a class="btn btn-primary" href="' . $redirecturl . '">' . get_string('reloadpage', 'mod_pingo') . '</a>';
             }


### PR DESCRIPTION
## Summary

Migrates the PINGO activity module to **Moodle 5.2** and **Bootstrap 5**.

## Changes

- **version.php**: raise minimum required Moodle version to 5.2 (`2026042000`); bump plugin to `1.1.0` (`2026060700`).
- **Bootstrap 4 → 5**:
  - `templates/pingo_sessionsoverview.mustache`: directional spacing utility `mr-1` → `me-1`.
  - `view.php` (5×): dismissible alerts migrated — `alert-block fade in` → `alert-dismissible fade show`, `class="close" data-dismiss="alert">×</button>` → `class="btn-close" data-bs-dismiss="alert" aria-label="…"`.
- **Dead code removal**: removed pre-Moodle 4.0 `$CFG->branch < 400` branches in `view.php`; simplified `FEATURE_MOD_PURPOSE` handling in `lib.php` (no longer guarded by `defined()`).
- **CHANGES.md**: added `1.1.0` changelog entry.

## Verification

- No remaining Bootstrap 4-only classes / `data-toggle` attributes; no `$CFG->branch` references.
- `php -l` clean for all changed PHP files.
- Not run inside a live Moodle 5.2 instance (no Moodle checkout available) — static checks + lint only.